### PR TITLE
Linux/Windows fixed compatibilities

### DIFF
--- a/yolov7_package/models/experimental.py
+++ b/yolov7_package/models/experimental.py
@@ -2,6 +2,7 @@ import numpy as np
 import random
 import torch
 import torch.nn as nn
+import pickle
 
 from .common import Conv, DWConv
 from yolov7_package.utils.google_utils import attempt_download
@@ -239,7 +240,7 @@ def attempt_load(weights, map_location=None):
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         attempt_download(w)
-        ckpt = torch.load(w, map_location=map_location)  # load
+        ckpt = torch.load(w, map_location=map_location, pickle_module=pickle)  # load
         model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().fuse().eval())  # FP32 model
     
     # Compatibility updates

--- a/yolov7_package/utils/google_utils.py
+++ b/yolov7_package/utils/google_utils.py
@@ -20,7 +20,7 @@ def gsutil_getsize(url=''):
 def attempt_download(file):
     # Attempt file download if does not exist
     file_name = file
-    file = Path(str(file).strip().replace("'", '').lower())
+    file = Path(str(file).strip().replace("'", ''))
 
     if not file.exists():
         wget.download(f'https://github.com/WongKinYiu/yolov7/releases/download/v0.1/{file.name}', out=str(file.parent))


### PR DESCRIPTION
- Paths in Linux are Case Sensitive by default, while they are not in windows. They broke me everything when I had a CamelCase folder in the path.
- Pickle default module differs from windows to linux. Specifying pickle instead of letting the system select its default avoids common compatibility issues.

These are the two lines of code I had to change to make my model work in different Linux environments, although I trained it in a Windows test machine.

(Thanks for your amazing package)